### PR TITLE
[이성태] WEEK8

### DIFF
--- a/이성태/WEEK8/두 큐 합 같게 만들기 for문 사용.py
+++ b/이성태/WEEK8/두 큐 합 같게 만들기 for문 사용.py
@@ -1,0 +1,40 @@
+from collections import deque
+queue1 = [1, 1]
+queue2 = [1, 5]
+'''
+불능 조건
+- (두 리스트의 총 합 // 2) 보다 큰 원소가 리스트에 존재하는 경우 불가함
+- 두 큐의 초기 길이는 같기 때문에 위의 조건만 고려하면 됨.
+- 총 가능한 순회 횟수는 q 길이의 * 3 - 2
+  => 모든 리스트를 n만큼 옮기고 다시 2n만큼 분배하는 최대의 경우가 있어서 총 3n, 리스트에 최소 한 개의 원소가 있어야 하므로 2를 빼줌
+필수 조건
+- deque 라이브러리 사용할 것.
+- 최솟값은 전역 변수로 설정하며, 이 전역변수가 넘어가면 바로 return 하여 시간 복잡도를 줄인다.
+'''
+
+
+def solution(queue1, queue2):
+    queue1, queue2 = deque(queue1), deque(queue2)
+    min_depth = len(queue1) * 3 - 2
+    sum1, sum2 = sum(queue1), sum(queue2)
+    depth = 0
+
+    for depth in range(min_depth):
+        try:
+            if sum1 > sum2:
+                element = queue1.popleft()
+                queue2.append(element)
+                sum1, sum2 = sum1 - element, sum2 + element
+            elif sum1 < sum2:
+                element = queue2.popleft()
+                queue1.append(element)
+                sum1, sum2 = sum1 + element, sum2 - element
+            else:
+                return depth
+        except:
+            break
+    return -1
+
+
+if __name__ == '__main__':
+    print(solution(queue1, queue2))

--- a/이성태/WEEK8/두 큐 합 같게 만들기.js
+++ b/이성태/WEEK8/두 큐 합 같게 만들기.js
@@ -1,0 +1,87 @@
+const queue1 = [3, 2, 7, 2]
+const queue2 = [4, 6, 5, 1]
+
+class Node {
+    constructor(data) {
+        this.data = data;
+        this.next = null;
+    }
+}
+
+class Queue {
+    constructor() {
+        this.head = null;
+        this.tail = null;
+        this.size = 0;
+        this._sum = 0;
+    }
+
+    push(data) {
+        const node = new Node(data);
+        if (this.head == null) {
+            this.head = node;
+            this.head.next = this.tail;
+        } else {
+            this.tail.next = node;
+        }
+        
+        this.tail = node;
+        this.size += 1;
+        this._sum += data;
+    }
+
+    length() {
+        return this.size;
+    }
+
+    sum() {
+        return this._sum;
+    }
+
+    popLeft() {
+        const popedData = this.head.data;
+        this.head = this.head.next;
+        this.size -= 1;
+        this.sum -= popedData;
+        return popedData;
+    }
+}
+
+function convertToQueue(arr) {
+    const queue = new Queue();
+    for (let i = 0; i < arr.length; i++) {
+        queue.push(arr[i])
+    }
+    return queue
+}
+
+function solution(queue1, queue2) {
+    queue1 = convertToQueue(queue1);
+    queue2 = convertToQueue(queue2);
+    const min_depth = queue1.length() * 3 - 2;
+    let sum1 = queue1._sum;
+    let sum2 = queue2._sum;
+
+    for (let i = 0; i < min_depth; i++) {
+        try {
+            if (sum1 > sum2) {
+                const element = queue1.popLeft();
+                queue2.push(element);
+                sum1 -= element
+                sum2 += element
+            } else if (sum1 < sum2) {
+                const element = queue2.popLeft();
+                queue1.push(element);
+                sum1 += element
+                sum2 -= element
+            } else {
+                return i
+            }
+        } catch {
+            break
+        }
+    }
+    return -1
+}
+
+console.log(solution(queue1, queue2));

--- a/이성태/WEEK8/두 큐 합 같게 만들기.py
+++ b/이성태/WEEK8/두 큐 합 같게 만들기.py
@@ -15,11 +15,11 @@ queue2 = [1, 5]
 
 def solution(queue1, queue2):
     queue1, queue2 = deque(queue1), deque(queue2)
-    min_depth = len(queue1) * 3 - 2
+    min_depth = len(queue1) * 3 - 3
     sum1, sum2 = sum(queue1), sum(queue2)
     depth = 0
 
-    while depth < min_depth:
+    while depth <= min_depth:
         try:
             if sum1 > sum2:
                 element = queue1.popleft()

--- a/이성태/WEEK8/두 큐 합 같게 만들기.py
+++ b/이성태/WEEK8/두 큐 합 같게 만들기.py
@@ -1,0 +1,42 @@
+from collections import deque
+queue1 = [1, 1]
+queue2 = [1, 5]
+'''
+불능 조건
+- (두 리스트의 총 합 // 2) 보다 큰 원소가 리스트에 존재하는 경우 불가함
+- 두 큐의 초기 길이는 같기 때문에 위의 조건만 고려하면 됨.
+- 총 가능한 순회 횟수는 q 길이의 * 3 - 2
+  => 모든 리스트를 n만큼 옮기고 다시 2n만큼 분배하는 최대의 경우가 있어서 총 3n, 리스트에 최소 한 개의 원소가 있어야 하므로 2를 빼줌
+필수 조건
+- deque 라이브러리 사용할 것.
+- 최솟값은 전역 변수로 설정하며, 이 전역변수가 넘어가면 바로 return 하여 시간 복잡도를 줄인다.
+'''
+
+
+def solution(queue1, queue2):
+    queue1, queue2 = deque(queue1), deque(queue2)
+    min_depth = len(queue1) * 3 - 2
+    sum1, sum2 = sum(queue1), sum(queue2)
+    depth = 0
+
+    while depth < min_depth:
+        try:
+            if sum1 > sum2:
+                element = queue1.popleft()
+                queue2.append(element)
+                sum1, sum2 = sum1 - element, sum2 + element
+            elif sum1 < sum2:
+                element = queue2.popleft()
+                queue1.append(element)
+                sum1, sum2 = sum1 + element, sum2 - element
+            else:
+                return depth
+        except:
+            break
+        depth += 1
+    else:
+        return -1
+
+
+if __name__ == '__main__':
+    print(solution(queue1, queue2))

--- a/이성태/calculate_test_average.py
+++ b/이성태/calculate_test_average.py
@@ -1,0 +1,3 @@
+tests = [float(input().split()[4][1:-3]) for _ in range(30)]
+print(tests)
+print(f'{sum(tests) / len(tests):.2}')


### PR DESCRIPTION
### 💻 코드 설명
```py
from collections import deque
queue1 = [1, 1]
queue2 = [1, 5]

'''
불능 조건
- (두 리스트의 총 합 // 2) 보다 큰 원소가 리스트에 존재하는 경우 불가함
- 두 큐의 초기 길이는 같기 때문에 위의 조건만 고려하면 됨.
- 총 가능한 순회 횟수는 q 길이의 * 3 - 2
  => 모든 리스트를 n만큼 옮기고 다시 2n만큼 분배하는 최대의 경우가 있어서 총 3n, 리스트에 최소 한 개의 원소가 있어야 하므로 2를 빼줌
필수 조건
- deque 라이브러리 사용할 것.
'''

def solution(queue1, queue2):
    queue1, queue2 = deque(queue1), deque(queue2)
    min_depth = len(queue1) * 3 - 3
    sum1, sum2 = sum(queue1), sum(queue2)
    depth = 0

    while depth <= min_depth:
        try:
            if sum1 > sum2:
                element = queue1.popleft()
                queue2.append(element)
                sum1, sum2 = sum1 - element, sum2 + element
            elif sum1 < sum2:
                element = queue2.popleft()
                queue1.append(element)
                sum1, sum2 = sum1 + element, sum2 - element
            else:
                return depth
        except:
            break
        depth += 1
    else:
        return -1


if __name__ == '__main__':
    print(solution(queue1, queue2))

```
맨 처음에 재귀를 생각했었는데, 반복문을 사용하는 게 전역변수도 쓰지 않고 코드도 상대적으로 간단해서 while을 통해서 문제를 풀었습니다. 먼저 최대로 할 수 있는 횟수를 생각했을 때 3n - 2가 나왔습니다.

1. 두 가지 리스트 모두 길이가 n이라고 가정했을 때, 하나의 리스트를 한 쪽 리스트로 모두 옮깁니다. 그리고 그 리스트를 모두 다른 리스트로 옮깁니다. 모두 다른 리스트로 옮기는 경우의 수까지 고려해야 모든 상황을 커버하기 떄문이었습니다.
```py
min_depth = len(queue1) * 3 - 3
```
> 하나의 리스트를 한 쪽 리스트로 모두 옮기기 -> n - 1
> 한 쪽의 리스트를 모두 다른 리스트로 옮기기 -> 2n - 2
이렇게 총 횟수는 3n - 3으로 나왔습니다. 그래서 최소 횟수를 3n - 3으로 초기화했습니다.

백트래킹을 사용하는 것이 아니라 단순히 반복하는 문제여서 합이 큰 쪽의 리스트에서 반대편 리스트로 pop -> insert하면 됩니다.

2. 합이 같을 때까지 반복합니다. 이때, 탈출 조건은 시도한 횟수가 3n - 3을 넘어서는 순간입니다. 이를 넘어가는 순간 불가능한 것이기 때문입니다.
```py
while depth <= min_depth:
    try:
        if sum1 > sum2:
            element = queue1.popleft()
            queue2.append(element)
            sum1, sum2 = sum1 - element, sum2 + element
        elif sum1 < sum2:
            element = queue2.popleft()
            queue1.append(element)
            sum1, sum2 = sum1 + element, sum2 - element
        else:
            return depth
    except:
        break
    depth += 1
```

3. 여기서 pop하는 과정에서 리스트가 비어있으면 인덱스 에러가 발생해서 원래 가은님처럼 `if sum1 == 0 or sum2 == 0: return  -1`로 작성했었는데, try except 구문으로 해보니까 시간 복잡도가 조금 줄었습니다. 그런데, 시간 복잡도 차이가 적어서 오히려 가독성이 좋은 전자가 더 좋은 방법이라고 생각이 듭니다!
```py
except:
    break
```

4. 조건을 탈출하면 불가능 한 것으로 판단하여 -1을 리턴합니다.
```py
while depth <= min_depth:
    ...
else:
    return -1
```

### 🤔 체감 난이도

맨 처음에 백트래킹으로 풀려고 해서 조금 헤맸습니다 :( 막상 풀이를 생각하니까 금방 풀리네요! 그런데 저도 가은님처럼 몇몇 케이스를 틀려가지고, 예외 상황 체크가 좀 부족했던 점이 아쉬웠습니다. 특히 while의 조건을 세울 때 얼마나 반복할까를 잘못 지정해서 그 부분이 가장 아쉬웠습니다.

pr 날리면서 생각해보니까 굳이 while쓰지 말고 for문으로 하는 게 조금 더 깔끔해 보이네요!
> for문으로 대체하니까 시간도 줄고 복잡해보이지도 않아서 이게 더 좋은 것 같은데 다른 분들은 어떤 방법이 더 나아 보이는지 궁금합니다~
```py
from collections import deque
queue1 = [1, 1]
queue2 = [1, 5]
'''
불능 조건
- (두 리스트의 총 합 // 2) 보다 큰 원소가 리스트에 존재하는 경우 불가함
- 두 큐의 초기 길이는 같기 때문에 위의 조건만 고려하면 됨.
- 총 가능한 순회 횟수는 q 길이의 * 3 - 2
  => 모든 리스트를 n만큼 옮기고 다시 2n만큼 분배하는 최대의 경우가 있어서 총 3n, 리스트에 최소 한 개의 원소가 있어야 하므로 2를 빼줌
필수 조건
- deque 라이브러리 사용할 것.
- 최솟값은 전역 변수로 설정하며, 이 전역변수가 넘어가면 바로 return 하여 시간 복잡도를 줄인다.
'''


def solution(queue1, queue2):
    queue1, queue2 = deque(queue1), deque(queue2)
    min_depth = len(queue1) * 3 - 2
    sum1, sum2 = sum(queue1), sum(queue2)
    depth = 0

    for depth in range(min_depth):
        try:
            if sum1 > sum2:
                element = queue1.popleft()
                queue2.append(element)
                sum1, sum2 = sum1 - element, sum2 + element
            elif sum1 < sum2:
                element = queue2.popleft()
                queue1.append(element)
                sum1, sum2 = sum1 + element, sum2 - element
            else:
                return depth
        except:
            break
    return -1


if __name__ == '__main__':
    print(solution(queue1, queue2))
```

### 🥔 기타 사항 / 질문

#20 가은님 pr에서 deque, queue를 사용한 풀이가 궁금하다고 하셔서, 일단 언어가 다르긴 하지만 queue를 사용한 풀이어서 언급했습니다!
